### PR TITLE
Bugfix: identical on functions raises internal error instead of same error as <=> 

### DIFF
--- a/lang/src/js/base/runtime.js
+++ b/lang/src/js/base/runtime.js
@@ -2598,20 +2598,13 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["identical3"], 2, $a, false); }
       return identical3(v1, v2);
     }, "identical3");
-    // JS function from Pyret values to JS true/false or throws
+    // JS function from Pyret values to Pyret booleans (or throws)
     function identical(v1, v2) {
-      if (arguments.length !== 2) { var $a=new Array(arguments.length); for (var $i=0;$i<arguments.length;$i++) { $a[$i]=arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["identical"], 2, $a, false); }
-      var ans = identical3(v1, v2);
-      if (thisRuntime.ffi.isEqual(ans)) { return true; }
-      else if (thisRuntime.ffi.isNotEqual(ans)) { return false; }
-      else if (thisRuntime.ffi.isUnknown(ans)) {
-        thisRuntime.ffi.throwEqualityException(getField(ans, "reason"), getField(ans, "value1"), getField(ans, "value2"));
-      }
+      if (arguments.length !== 2) { var $a = new Array(arguments.length); for (var $i = 0; $i < arguments.length; $i++) { $a[$i] = arguments[$i]; } throw thisRuntime.ffi.throwArityErrorC(["identical"], 2, $a, false); }
+      return safeCall(function () {
+        return identical3(v1, v2);
+      }, equalityToBool, "identical");
     };
-    // Pyret function from Pyret values to Pyret booleans (or throws)
-    var identicalPy = makeFunction(function(v1, v2) {
-      return makeBoolean(identical(v1, v2));
-    }, "identical");
 
     var gensymCounter = Math.floor(Math.random() * 1000);
     var gensym = makeFunction(function(base) {
@@ -6041,7 +6034,7 @@ function (Namespace, jsnums, codePoint, util, exnStackParser, loader, seedrandom
       'ref-freeze' : makeFunction(freezeRef, "ref-freeze"),
 
       'identical3': identical3Py,
-      'identical': identicalPy,
+      'identical': makeFunction(identical, "identical"),
       'equal-now3': makeFunction(equalNow3, "equal-now3"),
       'equal-now': makeFunction(equalNow, "equal-now"),
       'equal-always3': makeFunction(equalAlways3, "equal-always3"),

--- a/lang/tests/pyret/tests/test-equality.arr
+++ b/lang/tests/pyret/tests/test-equality.arr
@@ -362,3 +362,16 @@ check "https://github.com/brownplt/pyret-lang/issues/895":
     [list: "top","mid-b"],
     [list: "top","mid-b","low-b-a"]])
 end
+
+fun is-function-equality-failure(exn):
+  E.is-equality-failure(exn) and exn.reason == "Functions"
+end
+
+check "function equality errors consistent (<=> vs identical vs identical3)":
+  f = lam(): 1 end
+  g = f
+
+  (f <=> g) raises-satisfies is-function-equality-failure
+  identical(f, g) raises-satisfies is-function-equality-failure
+  E.to-boolean(identical3(f, g)) raises-satisfies is-function-equality-failure
+end


### PR DESCRIPTION
## Bug: 
See ticket descriptions ([sandbox](https://github.com/sandboxnu/pyret/issues/3), [brownplt](https://github.com/brownplt/pyret-lang/issues/1845))

Screenshot of bug example: 
<img width="2227" height="795" alt="image" src="https://github.com/user-attachments/assets/5463bdb8-77ad-4d68-a895-1fe418133c86" />

[Docs on equality comparisons in Pyret](https://pyret.org/docs/latest/equality.html)

## Solution: 
- In the Pyret runtime, `identical` was calling the `identical3` predicate function "bare" without `safeCall` (like how other equality funciotns ex: `equalNow` do) --> this resulted in an unstructured `throwEqualityException` being thrown directly and hence the unpretty error
- Fix was to remove the `identicalPy` function and instead export `identical` as a pyret function (similar to how other equality methods work) via `makeFunction` so that it uses `safeCall` 
- New flow: `identical3` --> `equalityToBool` --> `throwEqualityException` inside a call to `safeCall` 
- Added test to verify equivalent error messages when comparing functions with `identical` and `<=>`
