### PR TITLE
#12: Add is-ignorable method to Ann in ast

### DIFF
--- a/lang/src/arr/compiler/anf-loop-compiler.arr
+++ b/lang/src/arr/compiler/anf-loop-compiler.arr
@@ -801,9 +801,9 @@ end
 fun compile-anns(visitor, step, binds :: List<N.ABind>, entry-label):
   var cur-target = entry-label
   new-cases = for lists.fold(acc from cl-empty, b from binds):
-    if A.is-a-blank(b.ann) or A.is-a-any(b.ann) block:
+    if b.ann.is-ignorable() block:
       acc
-    else if A.is-a-tuple(b.ann) and b.ann.fields.all(lam(a): A.is-a-blank(a) or A.is-a-any(a) end):
+    else if A.is-a-tuple(b.ann) and b.ann.fields.all(lam(a): a.is-ignorable() end):
       new-label = visitor.make-label()
       new-case =
         j-case(cur-target,
@@ -861,7 +861,7 @@ fun compile-annotated-let(visitor, b :: BindType, compiled-e :: DAG.CaseResults%
       raise(string-append(string-append("Unknown ", b.value.label()), " in compile-annotated-let"))
     end
   shadow b = b.value
-  if A.is-a-blank(b.ann) or A.is-a-any(b.ann):
+  if b.ann.is-ignorable():
     c-block(
       j-block(
         cl-append(
@@ -872,7 +872,7 @@ fun compile-annotated-let(visitor, b :: BindType, compiled-e :: DAG.CaseResults%
         ),
       compiled-body.new-cases
       )
-  else if A.is-a-tuple(b.ann) and b.ann.fields.all(lam(a): A.is-a-blank(a) or A.is-a-any(a) end):
+  else if A.is-a-tuple(b.ann) and b.ann.fields.all(lam(a): a.is-ignorable() end):
     step = visitor.cur-step
     after-ann = visitor.make-label()
     after-ann-case = j-case(after-ann, j-block(compiled-body.block.stmts))
@@ -1833,7 +1833,7 @@ compiler-visitor = {
     fun make-variant-constructor(l2, base-id, brands-id, members, refl-name, refl-ref-fields-mask, refl-fields, constructor-id):
 
       nonblank-anns = for filter(m from members):
-        not(A.is-a-blank(m.bind.ann)) and not(A.is-a-any(m.bind.ann))
+        not(m.bind.ann.is-ignorable())
       end
       compiled-anns = for fold(acc from {anns: cl-empty, others: cl-empty}, m from nonblank-anns):
         compiled = compile-ann(m.bind.ann, none, self)

--- a/lang/src/arr/compiler/anf.arr
+++ b/lang/src/arr/compiler/anf.arr
@@ -181,7 +181,7 @@ fun anf(e :: A.Expr, k :: ANFCont) -> N.AExpr:
         | link(f, r) =>
           cases(A.LetBind) f:
             | s-var-bind(l2, b, val) =>
-              if A.is-a-blank(b.ann) or A.is-a-any(b.ann):
+              if b.ann.is-ignorable():
                 anf-name(val, "var", lam(new-val):
                       N.a-var(l2, N.a-bind(l2, b.id, b.ann), N.a-val(new-val.l, new-val),
                         anf(A.s-let-expr(l, r, body, blocky), k))
@@ -299,7 +299,7 @@ fun anf(e :: A.Expr, k :: ANFCont) -> N.AExpr:
       anf(A.s-let-expr(l, bindings, A.s-id(l, name.id), false), k)
 
     | s-lam(l, name, params, args, ret, doc, body, _, _, _) =>
-      if A.is-a-blank(ret) or A.is-a-any(ret):
+      if ret.is-ignorable():
         k(N.a-lam(l, name, args.map(lam(a): N.a-bind(a.l, a.id, a.ann) end), ret, anf-term(body)))
       else:
         temp = mk-id(l, "ann_check_temp")
@@ -309,7 +309,7 @@ fun anf(e :: A.Expr, k :: ANFCont) -> N.AExpr:
                 A.s-id(l, temp.id), false))))
       end
     | s-method(l, name, params, args, ret, doc, body, _, _, _) =>
-      if A.is-a-blank(ret) or A.is-a-any(ret):
+      if ret.is-ignorable():
         k(N.a-method(l, name, args.map(lam(a): N.a-bind(a.l, a.id, a.ann) end), ret, anf-term(body)))
       else:
         temp = mk-id(l, "ann_check_temp")

--- a/lang/src/arr/trove/ast.arr
+++ b/lang/src/arr/trove/ast.arr
@@ -1781,15 +1781,19 @@ data Ann:
   | a-blank with:
     method label(self): "a-blank" end,
     method tosource(self): str-any end,
+    method is-ignorable(self): true end,
   | a-any(l :: Loc) with:
     method label(self): "a-any" end,
     method tosource(self): str-any end,
+    method is-ignorable(self): true end,
   | a-name(l :: Loc, id :: Name) with:
     method label(self): "a-name" end,
     method tosource(self): self.id.tosource() end,
+    method is-ignorable(self): false end,
   | a-type-var(l :: Loc, id :: Name) with:
     method label(self): "a-type-var" end,
     method tosource(self): self.id.tosource() end,
+    method is-ignorable(self): false end,
   | a-arrow(l :: Loc, args :: List<Ann>, ret :: Ann, use-parens :: Boolean) with:
     method label(self): "a-arrow" end,
     method tosource(self):
@@ -1803,6 +1807,7 @@ data Ann:
         ann
       end
     end,
+    method is-ignorable(self): false end,
   | a-arrow-argnames(l :: Loc, args :: List<AField>, ret :: Ann, use-parens :: Boolean) with:
     method label(self): "a-arrow-argnames" end,
     method tosource(self):
@@ -1818,21 +1823,25 @@ data Ann:
         ann
       end
     end,
+    method is-ignorable(self): false end,
   | a-method(l :: Loc, args :: List<Ann>, ret :: Ann) with:
     method label(self): "a-method" end,
     method tosource(self): PP.str("NYI: A-method") end,
+    method is-ignorable(self): false end,
   | a-record(l :: Loc, fields :: List<AField>) with:
     method label(self): "a-record" end,
     method tosource(self):
       PP.surround-separate(INDENT, 1, PP.lbrace + PP.rbrace, PP.lbrace, PP.commabreak, PP.rbrace,
         self.fields.map(_.tosource()))
     end,
+    method is-ignorable(self): false end,
   | a-tuple(l :: Loc, fields :: List<Ann>) with:
     method label(self): "a-tuple" end,
     method tosource(self):
       PP.surround-separate(INDENT, 1, PP.lbrace + PP.rbrace, PP.lbrace, PP.semibreak, PP.rbrace,
         self.fields.map(_.tosource()))
     end,
+    method is-ignorable(self): false end,
   | a-app(l :: Loc, ann :: Ann, args :: List<Ann>) with:
     method label(self): "a-app" end,
     method tosource(self):
@@ -1840,15 +1849,19 @@ data Ann:
           + PP.group(PP.langle + PP.nest(INDENT,
             PP.separate(PP.commabreak, self.args.map(_.tosource()))) + PP.rangle))
     end,
+    method is-ignorable(self): false end,
   | a-pred(l :: Loc, ann :: Ann, exp :: Expr) with:
     method label(self): "a-pred" end,
     method tosource(self): self.ann.tosource() + str-percent + PP.parens(self.exp.tosource()) end,
+    method is-ignorable(self): false end,
   | a-dot(l :: Loc, obj :: Name, field :: String) with:
     method label(self): "a-dot" end,
     method tosource(self): self.obj.tosource() + PP.str("." + self.field) end,
+    method is-ignorable(self): false end,
   | a-checked(checked :: Ann, residual :: Ann) with:
     method label(self): "a-checked" end,
-    method tosource(self): self.residual.tosource() end
+    method tosource(self): self.residual.tosource() end,
+    method is-ignorable(self): false end
 sharing:
   method visit(self, visitor):
     self._match(visitor, lam(val): raise("No visitor field for " + self.label()) end)

--- a/lang/src/arr/trove/ast.arr
+++ b/lang/src/arr/trove/ast.arr
@@ -1780,20 +1780,16 @@ end
 data Ann:
   | a-blank with:
     method label(self): "a-blank" end,
-    method tosource(self): str-any end,
-    method is-ignorable(self): true end,
+    method tosource(self): str-any end
   | a-any(l :: Loc) with:
     method label(self): "a-any" end,
-    method tosource(self): str-any end,
-    method is-ignorable(self): true end,
+    method tosource(self): str-any end
   | a-name(l :: Loc, id :: Name) with:
     method label(self): "a-name" end,
-    method tosource(self): self.id.tosource() end,
-    method is-ignorable(self): false end,
+    method tosource(self): self.id.tosource() end
   | a-type-var(l :: Loc, id :: Name) with:
     method label(self): "a-type-var" end,
-    method tosource(self): self.id.tosource() end,
-    method is-ignorable(self): false end,
+    method tosource(self): self.id.tosource() end
   | a-arrow(l :: Loc, args :: List<Ann>, ret :: Ann, use-parens :: Boolean) with:
     method label(self): "a-arrow" end,
     method tosource(self):
@@ -1806,8 +1802,7 @@ data Ann:
       else:
         ann
       end
-    end,
-    method is-ignorable(self): false end,
+    end
   | a-arrow-argnames(l :: Loc, args :: List<AField>, ret :: Ann, use-parens :: Boolean) with:
     method label(self): "a-arrow-argnames" end,
     method tosource(self):
@@ -1822,49 +1817,48 @@ data Ann:
       else:
         ann
       end
-    end,
-    method is-ignorable(self): false end,
+    end
   | a-method(l :: Loc, args :: List<Ann>, ret :: Ann) with:
     method label(self): "a-method" end,
-    method tosource(self): PP.str("NYI: A-method") end,
-    method is-ignorable(self): false end,
+    method tosource(self): PP.str("NYI: A-method") end
   | a-record(l :: Loc, fields :: List<AField>) with:
     method label(self): "a-record" end,
     method tosource(self):
       PP.surround-separate(INDENT, 1, PP.lbrace + PP.rbrace, PP.lbrace, PP.commabreak, PP.rbrace,
         self.fields.map(_.tosource()))
-    end,
-    method is-ignorable(self): false end,
+    end
   | a-tuple(l :: Loc, fields :: List<Ann>) with:
     method label(self): "a-tuple" end,
     method tosource(self):
       PP.surround-separate(INDENT, 1, PP.lbrace + PP.rbrace, PP.lbrace, PP.semibreak, PP.rbrace,
         self.fields.map(_.tosource()))
-    end,
-    method is-ignorable(self): false end,
+    end
   | a-app(l :: Loc, ann :: Ann, args :: List<Ann>) with:
     method label(self): "a-app" end,
     method tosource(self):
       PP.group(self.ann.tosource()
           + PP.group(PP.langle + PP.nest(INDENT,
             PP.separate(PP.commabreak, self.args.map(_.tosource()))) + PP.rangle))
-    end,
-    method is-ignorable(self): false end,
+    end
   | a-pred(l :: Loc, ann :: Ann, exp :: Expr) with:
     method label(self): "a-pred" end,
-    method tosource(self): self.ann.tosource() + str-percent + PP.parens(self.exp.tosource()) end,
-    method is-ignorable(self): false end,
+    method tosource(self): self.ann.tosource() + str-percent + PP.parens(self.exp.tosource()) end
   | a-dot(l :: Loc, obj :: Name, field :: String) with:
     method label(self): "a-dot" end,
-    method tosource(self): self.obj.tosource() + PP.str("." + self.field) end,
-    method is-ignorable(self): false end,
+    method tosource(self): self.obj.tosource() + PP.str("." + self.field) end
   | a-checked(checked :: Ann, residual :: Ann) with:
     method label(self): "a-checked" end,
-    method tosource(self): self.residual.tosource() end,
-    method is-ignorable(self): false end
+    method tosource(self): self.residual.tosource() end
 sharing:
   method visit(self, visitor):
     self._match(visitor, lam(val): raise("No visitor field for " + self.label()) end)
+  end,
+  method is-ignorable(self):
+    cases(Ann) self:
+      | a-blank => true
+      | a-any(_) => true
+      | otherwise => false
+    end
   end
 end
 

--- a/lang/src/arr/trove/ast.arr
+++ b/lang/src/arr/trove/ast.arr
@@ -1857,7 +1857,17 @@ sharing:
     cases(Ann) self:
       | a-blank => true
       | a-any(_) => true
-      | otherwise => false
+      | a-name(_, _) => false
+      | a-type-var(_, _) => false
+      | a-arrow(_, _, _, _) => false
+      | a-arrow-argnames(_, _, _, _) => false
+      | a-method(_, _, _) => false
+      | a-record(_, _) => false
+      | a-tuple(_, _) => false
+      | a-app(_, _, _) => false
+      | a-pred(_, _, _) => false
+      | a-dot(_, _, _) => false
+      | a-checked(_, _) => false
     end
   end
 end

--- a/lang/src/arr/trove/ast.arr
+++ b/lang/src/arr/trove/ast.arr
@@ -1780,10 +1780,12 @@ end
 data Ann:
   | a-blank with:
     method label(self): "a-blank" end,
-    method tosource(self): str-any end
+    method tosource(self): str-any end,
+    method is-ignorable(self): true end
   | a-any(l :: Loc) with:
     method label(self): "a-any" end,
-    method tosource(self): str-any end
+    method tosource(self): str-any end,
+    method is-ignorable(self): true end
   | a-name(l :: Loc, id :: Name) with:
     method label(self): "a-name" end,
     method tosource(self): self.id.tosource() end
@@ -1854,21 +1856,7 @@ sharing:
     self._match(visitor, lam(val): raise("No visitor field for " + self.label()) end)
   end,
   method is-ignorable(self):
-    cases(Ann) self:
-      | a-blank => true
-      | a-any(_) => true
-      | a-name(_, _) => false
-      | a-type-var(_, _) => false
-      | a-arrow(_, _, _, _) => false
-      | a-arrow-argnames(_, _, _, _) => false
-      | a-method(_, _, _) => false
-      | a-record(_, _) => false
-      | a-tuple(_, _) => false
-      | a-app(_, _, _) => false
-      | a-pred(_, _, _) => false
-      | a-dot(_, _, _) => false
-      | a-checked(_, _) => false
-    end
+    false
   end
 end
 


### PR DESCRIPTION
Fixes #12 

Changes:
- [x] Created is-ignorable method in Ann definition of ast.arr
- [x] updated usage of A.is-a-blank(a) or A.is-a-any(a) with a.is-ignorable across files