### PR TITLE
Bugfix: identical on functions raises internal error instead of same error as <=>

### DIFF
--- a/lang/src/arr/trove/error.arr
+++ b/lang/src/arr/trove/error.arr
@@ -2302,8 +2302,12 @@ data RuntimeError:
               else if src-available(loc):
                 cases(O.Option) maybe-ast(loc):
                   | some(ast) =>
-                    left-loc =  ast.left.l
-                    right-loc = ast.right.l
+                    {left-loc; right-loc} = cases(Any) ast:
+                      | s-op(_, _, _, left-expr, right-expr) =>
+                        {left-expr.l; right-expr.l}
+                      | s-app(_, _, args) =>
+                        {args.get(0).l; args.get(1).l}
+                    end
                     [ED.sequence:
                       ed-intro("equality comparison", loc, -1, true),
                       ED.cmcode(loc),


### PR DESCRIPTION
## Bug: 
Screenshot of bug example: 
<img width="2237" height="1071" alt="image" src="https://github.com/user-attachments/assets/cf611b04-209b-4dac-9510-c7cb4327af9b" />

[Docs on equality comparisons in Pyret](https://pyret.org/docs/latest/equality.html)

Closes  [sandbox](https://github.com/sandboxnu/pyret/issues/3), [brownplt](https://github.com/brownplt/pyret-lang/issues/1845)

- equality error handling method in `error.arr` expected an AST operator node with `.left` and `.right` fields (ex: `f <=> g` would pass in `f` as `.left` and `g` as `.right`), whereas handling errors with calls like `identical` passes in an AST with `.args` so fallback behavior is the ugly error shown above 
## Behavior & Design Decisions

- fix is to alter that portion of the error handling to match on the AST node to handle either `.args` or `.left`/`.right` fields and treat them the same way 
- error occurs on calls to `equal-now` and `equal-always` as well 

## Testing
- tested locally by running CPO with local pyret lang, verified correct error shown for `identical`, `equal-now`, `equal-always`
<img width="2240" height="1313" alt="image" src="https://github.com/user-attachments/assets/8cf99da9-c12c-4d44-a18e-be29664ae802" />

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] My changes compile and run locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have moved the ticket to "In Review", assigned myself to this PR, and requested reviewers
- [x] I have included screenshots/recordings for any UI changes

## (Optional) Notes for Reviewers 
Would like one of Zack/Owen to verify this behavior locally on their machines as well! Also will poke around to make sure this works as expected for all equality methods, right now have just tested with the three listed above
