### PR TITLE
 #35: Better load-table error message for bogus source

### DIFF
--- a/lang/src/arr/trove/error.arr
+++ b/lang/src/arr/trove/error.arr
@@ -720,40 +720,35 @@ data RuntimeError:
           | some(ast) =>
             cases(Any) ast:
               | s-load-table(_, _, specs) =>
-                maybe-src-spec = specs.find(lam(s): cases(Any) s: | s-table-src(_,_) => true | else => false end end)
-                cases(O.Option) maybe-src-spec:
-                  | some(src-spec) =>
-                    [ED.error:
-                      ed-intro("table loader expression", self.loc, -1, true),
-                      ED.cmcode(self.loc),
-                      [ED.para:
-                        ED.text("The "),
-                        ED.highlight(ED.text("source"), [ED.locs: src-spec.l], -2),
-                        ED.text(" could not be loaded:")],
-                      ED.embed(self.non-obj)]
-                  | none =>
-                    [ED.error:
-                      ed-intro("table loader expression", self.loc, -1, true),
-                      ED.cmcode(self.loc),
-                      [ED.para: ED.text("The source could not be loaded:")],
-                      ED.embed(self.non-obj)]
-                end
+                # well-formedness enforces exactly one s-table-src in specs (well-formed.arr:1023),
+                # so .find() always returns some and projecting with .value is safe
+                src-spec = specs.find(lam(s): cases(Any) s: | s-table-src(_,_) => true | else => false end end).value
+                [ED.error:
+                  ed-intro("table loader expression", self.loc, -1, true),
+                  ED.cmcode(self.loc),
+                  [ED.para:
+                    ED.text("The "),
+                    ED.highlight(ED.text("source"), [ED.locs: src-spec.l], 0),
+                    ED.text(" could not be loaded:")],
+                  ED.embed(self.non-obj)]
               | s-dot(_,_,_) =>
+                obj-loc = ast.obj.l
                 [ED.error:
                   ed-intro("field lookup expression", self.loc, -1, true),
                   ED.cmcode(self.loc),
                   [ED.para:
                     ED.text("The "),
-                    ED.highlight(ED.text("left side"), [ED.locs: ast.obj.l], 0),
+                    ED.highlight(ED.text("left side"), [ED.locs: obj-loc], 0),
                     ED.text(" was not an object:")],
                   ED.embed(self.non-obj)]
               | s-app(_,f,_) =>
+                obj-loc = f.obj.l
                 [ED.error:
                   ed-intro("field lookup expression", self.loc, -1, true),
                   ED.cmcode(self.loc),
                   [ED.para:
                     ED.text("The "),
-                    ED.highlight(ED.text("left side"), [ED.locs: f.obj.l], 0),
+                    ED.highlight(ED.text("left side"), [ED.locs: obj-loc], 0),
                     ED.text(" was not an object:")],
                   ED.embed(self.non-obj)]
             end

--- a/lang/src/arr/trove/error.arr
+++ b/lang/src/arr/trove/error.arr
@@ -718,18 +718,29 @@ data RuntimeError:
       else if src-available(self.loc):
         cases(O.Option) maybe-ast(self.loc):
           | some(ast) =>
-            shadow ast = cases(Any) ast:
-              | s-dot(_,_,_) => ast
-              | s-app(_,f,_) => f
+            if self.field == "load":
+              # load-table ... source: "..." end desugars to "...".load(...),
+              # so self.field is "load" and the pre-desugar AST is s-load-table.
+              [ED.error:
+                ed-intro("table loader expression", self.loc, -1, true),
+                ED.cmcode(self.loc),
+                [ED.para:
+                  ED.text("The source could not be loaded:")],
+                ED.embed(self.non-obj)]
+            else:
+              shadow ast = cases(Any) ast:
+                | s-dot(_,_,_) => ast
+                | s-app(_,f,_) => f
+              end
+              [ED.error:
+                ed-intro("field lookup expression", self.loc, -1, true),
+                ED.cmcode(self.loc),
+                [ED.para:
+                  ED.text("The "),
+                  ED.highlight(ED.text("left side"), [ED.locs: ast.obj.l], 0),
+                  ED.text(" was not an object:")],
+                ED.embed(self.non-obj)]
             end
-            [ED.error:
-              ed-intro("field lookup expression", self.loc, -1, true),
-              ED.cmcode(self.loc),
-              [ED.para:
-                ED.text("The "),
-                ED.highlight(ED.text("left side"), [ED.locs: ast.obj.l], 0),
-                ED.text(" was not an object:")],
-              ED.embed(self.non-obj)]
           | none =>
             [ED.error:
               ed-intro("field lookup expression", self.loc, -1, true),

--- a/lang/src/arr/trove/error.arr
+++ b/lang/src/arr/trove/error.arr
@@ -718,28 +718,44 @@ data RuntimeError:
       else if src-available(self.loc):
         cases(O.Option) maybe-ast(self.loc):
           | some(ast) =>
-            if self.field == "load":
-              # load-table ... source: "..." end desugars to "...".load(...),
-              # so self.field is "load" and the pre-desugar AST is s-load-table.
-              [ED.error:
-                ed-intro("table loader expression", self.loc, -1, true),
-                ED.cmcode(self.loc),
-                [ED.para:
-                  ED.text("The source could not be loaded:")],
-                ED.embed(self.non-obj)]
-            else:
-              shadow ast = cases(Any) ast:
-                | s-dot(_,_,_) => ast
-                | s-app(_,f,_) => f
-              end
-              [ED.error:
-                ed-intro("field lookup expression", self.loc, -1, true),
-                ED.cmcode(self.loc),
-                [ED.para:
-                  ED.text("The "),
-                  ED.highlight(ED.text("left side"), [ED.locs: ast.obj.l], 0),
-                  ED.text(" was not an object:")],
-                ED.embed(self.non-obj)]
+            cases(Any) ast:
+              | s-load-table(_, _, specs) =>
+                maybe-src-spec = specs.find(lam(s): cases(Any) s: | s-table-src(_,_) => true | else => false end end)
+                cases(O.Option) maybe-src-spec:
+                  | some(src-spec) =>
+                    [ED.error:
+                      ed-intro("table loader expression", self.loc, -1, true),
+                      ED.cmcode(self.loc),
+                      [ED.para:
+                        ED.text("The "),
+                        ED.highlight(ED.text("source"), [ED.locs: src-spec.l], -2),
+                        ED.text(" could not be loaded:")],
+                      ED.embed(self.non-obj)]
+                  | none =>
+                    [ED.error:
+                      ed-intro("table loader expression", self.loc, -1, true),
+                      ED.cmcode(self.loc),
+                      [ED.para: ED.text("The source could not be loaded:")],
+                      ED.embed(self.non-obj)]
+                end
+              | s-dot(_,_,_) =>
+                [ED.error:
+                  ed-intro("field lookup expression", self.loc, -1, true),
+                  ED.cmcode(self.loc),
+                  [ED.para:
+                    ED.text("The "),
+                    ED.highlight(ED.text("left side"), [ED.locs: ast.obj.l], 0),
+                    ED.text(" was not an object:")],
+                  ED.embed(self.non-obj)]
+              | s-app(_,f,_) =>
+                [ED.error:
+                  ed-intro("field lookup expression", self.loc, -1, true),
+                  ED.cmcode(self.loc),
+                  [ED.para:
+                    ED.text("The "),
+                    ED.highlight(ED.text("left side"), [ED.locs: f.obj.l], 0),
+                    ED.text(" was not an object:")],
+                  ED.embed(self.non-obj)]
             end
           | none =>
             [ED.error:

--- a/lang/src/arr/trove/error.arr
+++ b/lang/src/arr/trove/error.arr
@@ -731,18 +731,11 @@ data RuntimeError:
                     ED.highlight(ED.text("source"), [ED.locs: src-spec.l], 0),
                     ED.text(" could not be loaded:")],
                   ED.embed(self.non-obj)]
-              | s-dot(_,_,_) =>
-                obj-loc = ast.obj.l
-                [ED.error:
-                  ed-intro("field lookup expression", self.loc, -1, true),
-                  ED.cmcode(self.loc),
-                  [ED.para:
-                    ED.text("The "),
-                    ED.highlight(ED.text("left side"), [ED.locs: obj-loc], 0),
-                    ED.text(" was not an object:")],
-                  ED.embed(self.non-obj)]
-              | s-app(_,f,_) =>
-                obj-loc = f.obj.l
+              | else =>
+                obj-loc = cases(Any) ast:
+                  | s-dot(_,_,_) => ast.obj.l
+                  | s-app(_,f,_) => f.obj.l
+                end
                 [ED.error:
                   ed-intro("field lookup expression", self.loc, -1, true),
                   ED.cmcode(self.loc),

--- a/lang/src/arr/trove/error.arr
+++ b/lang/src/arr/trove/error.arr
@@ -720,9 +720,16 @@ data RuntimeError:
           | some(ast) =>
             cases(Any) ast:
               | s-load-table(_, _, specs) =>
-                # well-formedness enforces exactly one s-table-src in specs (well-formed.arr:1023),
-                # so .find() always returns some and projecting with .value is safe
-                src-spec = specs.find(lam(s): cases(Any) s: | s-table-src(_,_) => true | else => false end end).value
+                # desugaring uses `.load(...)`, which can fail (See brownplt/pyret-lang#1855).
+                # well-formedness enforces exactly one s-table-src (see well-formed.arr),
+                # so `.find(...)` always returns `some` and projecting with `.value` is safe.
+                # `is-s-table-src` cannot be used without creating a cyclic module dependency.
+                src-spec = specs.find(lam(s): 
+                  cases(Any) s: 
+                  | s-table-src(_,_) => true 
+                  | else => false 
+                  end
+                end).value
                 [ED.error:
                   ed-intro("table loader expression", self.loc, -1, true),
                   ED.cmcode(self.loc),


### PR DESCRIPTION
Better error message (instead of 'something went wrong' internal error) for using a bogus `source:` when calling `load-table` by adding case for `s-load-table` to <insert> in `error.arr`

Closes [sandbox](https://github.com/orgs/sandboxnu/projects/29/views/1?pane=issue&itemId=156693540&issue=sandboxnu%7Cpyret%7C35), [brownplt](https://github.com/brownplt/pyret-lang/issues/1855)

## Behavior & Design Decisions

- all changes are in `lookup-non-object.render-fancy-reason` --> the fix handles the case wher a `load-table` expression has an invalid `source` by adding a new branch to the `case(Any) ast:` block trhat previous only handled `s-dot` and `s-app` to now also handle `s-load-table` --> finds the `s-table-src`, shows a "table loader expression" error with a hoverable source to hihglight the source line --> other error logic unchanged
- replaced previous internal error message with the following: 
```
Evaluating this table loader expression errored: 
<code here> 
The source could not be loaded: 
<source here> 
```
where 'table loader expression' is hoverable to highlight the call and 'source' is hoverable to highlight the source 

## Testing

Tested on CPO locally pointing to my local pyret lang by verifying GOOD error messages still work and this BAD error message is replaced with the proper one + that highlighting works as expected 

- regression test on normal field lookup on a non-object
<img width="2247" height="1381" alt="image" src="https://github.com/user-attachments/assets/2bf18d1c-3a36-402b-b3a8-aebc774430e8" />
- regression test on non-object that goes to `s-app` branch
<img width="2236" height="1304" alt="image" src="https://github.com/user-attachments/assets/1c52bf89-8043-47b2-978a-22537f0c4d41" />
- regression test field lookup on non-object that's a non-string 
<img width="2222" height="1346" alt="image" src="https://github.com/user-attachments/assets/1baf1cfc-c172-469a-b47a-fd629df7b3af" />
- error from ticket
(before) 
<img width="1915" height="867" alt="image" src="https://github.com/user-attachments/assets/97ac68e1-1a18-4e38-9d4d-c9f93a6de587" />
(after, with hover highlighting) 
<img width="2204" height="962" alt="image" src="https://github.com/user-attachments/assets/0fcb4767-972a-4775-a0ad-4fceb1da974c" />
- another example of error 
(after, with non-string bogus source)
<img width="2245" height="433" alt="image" src="https://github.com/user-attachments/assets/b484fd65-78d8-4907-a895-0e6f92880fc1" />
- another example of error 
(after, with an expression as the source) 
<img width="2233" height="606" alt="image" src="https://github.com/user-attachments/assets/fca6ed02-60ac-4317-a010-85b571bb8573" />

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] My changes compile and run locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have moved the ticket to "In Review", assigned myself to this PR, and requested reviewers
- [x] I have included screenshots/recordings for any UI changes
