### PR TITLE
check examples' correctness; more streamlining between pyret docs and pollenboots repo

### DIFF
--- a/new-docs/Makefile
+++ b/new-docs/Makefile
@@ -11,6 +11,9 @@ once:
 	make pollenboots
 	raco pollen render index.ptree
 
+debug-examples:
+	./debug-examples.sh
+
 pollenboots:
 	git clone https://github.com/ds26gte/pollenboots
 
@@ -18,6 +21,8 @@ clean:
 	find . -name compiled -type d -exec rm -fr {} \; || true
 	find [^p]* -name \*.html -delete || true
 	find pl* -name \*.html -delete || true
+	find . -name .image\*png -delete || true
+	find . -name .examples\*arr -delete || true
 	make cleanglob
 
 cleanglob:

--- a/new-docs/abbrevs.rkt
+++ b/new-docs/abbrevs.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
 (require "pollenboots/utils.rkt")
+(require "pyret-docs.rkt")
 
 (provide (all-defined-out))
 

--- a/new-docs/debug-examples.sh
+++ b/new-docs/debug-examples.sh
@@ -1,0 +1,11 @@
+#! /usr/bin/env bash
+
+for f in **/.examples-*.arr; do
+  if pyret $f 2>&1 | grep -q 'compilation errors'; then
+    echo
+    echo ---------------
+    echo Error in:
+    cat $f
+    echo
+  fi
+done

--- a/new-docs/pyret-docs.rkt
+++ b/new-docs/pyret-docs.rkt
@@ -218,6 +218,39 @@
                 (pre ([class "pyret-display"]) ,type-name)
                 ,@body)]))
 
+(define (a-id name . args)
+  (if (cons? args) (first args) name)) ;autoinclude tt?
+
+(define (a-arrow . typs)
+  ; (printf "### doing a-arrow of ~s\n" typs)
+  (set! typs
+    (filter (lambda (typ) (not (equal? typ "Brand"))) typs))
+  (set! typs
+    (map (lambda (typ) (if (null? typ) "()" typ)) typs))
+  (when (= (length typs) 1)
+    (set! typs (cons "()" typs)))
+  (let ([res
+          `(span () ,@(add-between typs ", " #:before-last " -> "))])
+    ; (printf "### a-arrow produced ~s\n" res)
+    res))
+
+(define (p-a-arrow . typs)
+  `(span () "(" ,(apply a-arrow typs) ")"))
+
+(define (a-app base . typs)
+  ; (printf "doing a-app base= ~s typs= ~s\n" base typs )
+  (set! typs (map (lambda (typ)
+                    (if (list? typ)
+                        (if (and (> (length typ) 1) (memq (first typ) '(ref-gloss-1 span)))
+                            typ
+                            `(span () ,@(add-between typ ", ")))
+                        typ)) typs))
+  ; (printf "### typs is now ~s\n" typs)
+  (set! typs `(span () ,@(add-between typs ", ")))
+  (let ([x `(span () ,base "<" ,typs ">")])
+    ; (printf "a-app ~s ~s ==> ~s\n" base typs x)
+    x))
+
 (define (a-ftype #:ml [ml #f] . typs)
   (let* ([arg-typs (drop-right typs 1)]
          [ret-typ (car (take-right typs 1))])

--- a/new-docs/trove/image.poly.pm
+++ b/new-docs/trove/image.poly.pm
@@ -13,18 +13,14 @@
 ◊(define (draw-pinhole x y img #:color [c 'black])
    (overlay/offset (overlay (line 10 0 c) (line 0 10 c)) x y img))
 
-◊(define counter 0)
-
-◊(define (get-counter)
-  (set! counter (+ counter 1))
-  counter)
+◊(define get-image-count (make-counter))
 
 ◊(define (image-2 image-obj)
          ◊; (printf "*** image-2 ~s\n" image-obj)
          (if (= (image-width image-obj) 0)
              `(span () "")
              (let ()
-               (define file (format ".image-~a.png" (get-counter)))
+               (define file (format ".image-~a.png" (get-image-count)))
                (save-image image-obj file)
                `(img ([src ,file])))))
 

--- a/new-docs/verbatim.rkt
+++ b/new-docs/verbatim.rkt
@@ -13,14 +13,27 @@
 (define (tt . elems)
   `(tt () ,@elems))
 
+(define (save-example-to-file strs file)
+  (call-with-output-file file
+    (lambda (o)
+      (fprintf o "# example in ~s, saved to ~s\n" (calc-here-path-from-project-root) file)
+      (for ([str strs])
+        (display str o)))
+    #:exists 'replace))
+
+(define get-examples-count (make-counter))
+
 (define (examples #:show-try-it [show-try-it #t] . elems)
   (if show-try-it
-      `(div ()
-            (p () (b () "Examples:"))
-            (pre ([class "pyret-highlight"]) ,@elems)
-            (a ([class "show-embed"]
-                [code ,(string-join elems " ")])
-               "(Try it!)"))
+      (let ()
+        (define file (format ".examples-~a.arr" (get-examples-count)))
+        (save-example-to-file elems file)
+        `(div ()
+              (p () (b () "Examples:"))
+              (pre ([class "pyret-highlight"]) ,@elems)
+              (a ([class "show-embed"]
+                  [code ,(string-join elems " ")])
+                 "(Try it!)")))
       (let ()
         (define elem-string (apply string-append elems))
         (printf "WARNING: examples ~s missing try-it in ~a\n" elem-string (calc-here-path-from-project-root))

--- a/new-docs/verbatim.rkt
+++ b/new-docs/verbatim.rkt
@@ -21,9 +21,12 @@
             (a ([class "show-embed"]
                 [code ,(string-join elems " ")])
                "(Try it!)"))
-      `(div ()
-            (p () (b () "Examples:"))
-            (pre ([class "pyret-highlight"]) ,@elems))))
+      (let ()
+        (define elem-string (apply string-append elems))
+        (printf "WARNING: examples ~s missing try-it in ~a\n" elem-string (calc-here-path-from-project-root))
+        `(div ()
+              (p () (b () "Examples:"))
+              (pre ([class "pyret-highlight"]) ,@elems)))))
 
 (define (verbatim #:style [style "nothing_special"] #:show-try-it [show-try-it #f] . elems)
   ; (printf "@@@ doing verbatim ~s\n" elems)


### PR DESCRIPTION
- Move counter routines to pollenboots as they're generally useful
- Move more Pyret-doc-specific defs to this repo (from pollenboots)
- examples now create temp files (using the general counter routine) containing the example, which can be checked by new script `debug-examples.sh` for correctness
- Add Makefile target `debug-examples` that uses the `debug-examples.sh` script